### PR TITLE
bugifx: can't parse domain which contains '-'

### DIFF
--- a/domaintools/__init__.py
+++ b/domaintools/__init__.py
@@ -52,7 +52,7 @@ class Domain(object):
     '''
     __whitespace_regex = re.compile(ur'\s+')
 
-    __domain_part_regex = re.compile(ur'(?!-)[A-Z\d-]{1,63}(?<!-)$', re.IGNORECASE)
+    __domain_part_regex = re.compile(ur'(?!-)[A-Z\d\-_]{1,63}(?<!-)$', re.IGNORECASE)
 
     def __init__(self, domain_string, allow_private=False):
         if not TLDS:

--- a/domaintools/tests.py
+++ b/domaintools/tests.py
@@ -42,6 +42,8 @@ valid_domains = [
     (u'goat.wtf', 'wtf', 'goat', None, False),
     # wildcard
     (u'goat.com.bn', 'com.bn', 'goat', None, False),
+    # include _
+    (u'hnzd8.weishangok_com.ag1671.com', 'com', 'ag1671', 'hnzd8.weishangok_com', False),
     ]
 
 valid_private_domains = [

--- a/domaintools/tests.py
+++ b/domaintools/tests.py
@@ -42,8 +42,6 @@ valid_domains = [
     (u'goat.wtf', 'wtf', 'goat', None, False),
     # wildcard
     (u'goat.com.bn', 'com.bn', 'goat', None, False),
-    # include *
-    (u'*.google.com', 'com', 'google', '*', False),
     ]
 
 valid_private_domains = [
@@ -82,6 +80,8 @@ invalid_domains = [
     u'a-.google.com',
     # include *
     u'*a.google.com',
+    # include *
+    u'*.google.com',
     ]
 
 invalid_private_domains = [


### PR DESCRIPTION
can't parse domain which contains '-' ,like `hnzd8.weishangok_com.ag1671.com`.